### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ python train.py --cfg configs/yamls/stage1.yaml
 ```
 
 ### Stage 2.
-Training stage 2 requires pretrained results from the stage 1. You can use your pretrained results, or download the weight from [Google Drive](https://drive.google.com/file/d/1Erjkho7O0bnZFawarntICRUCroaKabRE/view?usp=sharing) save as `checkpoints/wham_stage1.tar.pth`.
+Training stage 2 requires pretrained results from the stage 1. You can use your pretrained results, or download the weight from [Google Drive](https://drive.google.com/file/d/1Erjkho7O0bnZFawarntICRUCroaKabRE/view?usp=sharing) save as `checkpoints/wham_stage1.pth.tar`.
 ```bash
 python train.py --cfg configs/yamls/stage2.yaml TRAIN.CHECKPOINT <PATH-TO-STAGE1-RESULTS>
 ```


### PR DESCRIPTION
This fixes typo from README.md of Stage 2 training of WHAM.
The content of pull request is critical, as this typo makes WHAM users to mistakenly conduct Stage 2 training of WHAM without loading checkpoint of Stage 1.